### PR TITLE
Refactor search logic

### DIFF
--- a/algorithm/ai_search_worker.ts
+++ b/algorithm/ai_search_worker.ts
@@ -1,69 +1,8 @@
 import { parentPort } from 'worker_threads'
-import Fuse, { IFuseOptions } from 'fuse.js'
-import * as OpenCC from 'opencc-js'
-
 import { search_index } from '@/config/root'
-import { SearchItem } from '@/types'
-
-const cn2jp = OpenCC.Converter({ from: 'cn', to: 'jp' })
-
-const options: IFuseOptions<SearchItem> = {
-  includeScore: true,
-  ignoreLocation: true,
-  ignoreFieldNorm: true,
-  threshold: 0.78,
-  keys: ['id'],
-}
-
-async function runSearch(q: string, n: number): Promise<SearchItem[]> {
-  const queryjp = cn2jp(q)
-  const queryai = await fetch(
-    `http://localhost:2998/findname?name=${encodeURIComponent(q)}`,
-  )
-    .then((res) => res.json())
-    .then((data) => data.ans[0] || '')
-    .catch(() => '')
-
-  console.log(`search: ${q}, AI answer: ${queryai}`)
-  const fuse = new Fuse(search_index, options)
-  const ai_res = fuse
-    .search(q + ' ' + queryai)
-    .map((result) => ({ item: result.item, score: result.score }))
-  const traditional_results = fuse
-    .search(q + ' ' + queryjp)
-    .map((result) => ({ item: result.item, score: result.score }))
-
-  const results: Array<{ item: SearchItem; score: number | undefined }> = []
-  for (const res of ai_res) {
-    if (res.score) {
-      results.push(res)
-    }
-  }
-  for (const res of traditional_results) {
-    if (res.score) {
-      const existing_result_index = results.findIndex(
-        (r) => r.item.id === res.item.id,
-      )
-      if (existing_result_index !== -1) {
-        if (results[existing_result_index].score && res.score) {
-          results[existing_result_index].score =
-            (results[existing_result_index].score ?? 0) / 2 +
-            (res.score ?? 0) / 2
-        }
-      } else {
-        results.push(res)
-      }
-    }
-  }
-  return results
-    .sort((a, b) => {
-      return (a.score ?? 0) - (b.score ?? 0)
-    })
-    .slice(0, n)
-    .map((result) => result.item)
-}
+import { aiSearchCore } from './search_core'
 
 parentPort?.on('message', async ({ q, n }: { q: string; n: number }) => {
-  const res = await runSearch(q, n)
+  const res = await aiSearchCore(q, n, search_index)
   parentPort?.postMessage(res)
 })

--- a/algorithm/search.ts
+++ b/algorithm/search.ts
@@ -1,32 +1,12 @@
-import Fuse, { IFuseOptions } from 'fuse.js'
-import * as OpenCC from 'opencc-js'
 import { Worker } from 'worker_threads'
 import { fileURLToPath } from 'url'
 import { dirname, join } from 'path'
 
 import { trim_file_path } from './url'
+import { cn2jp, runsearch } from './search_core'
 
-import { BucketFiles, SearchItem, SearchList } from '@/types'
+import { BucketFiles, SearchItem } from '@/types'
 import { search_index } from '@/config/root'
-
-// export const cn2tw = OpenCC.Converter({ from: 'cn', to: 'tw' })
-// export const tw2cn = OpenCC.Converter({ from: 'tw', to: 'cn' })
-export const cn2jp = OpenCC.Converter({ from: 'cn', to: 'jp' })
-
-const options: IFuseOptions<SearchItem> = {
-  includeScore: true,
-  ignoreLocation: true,
-  ignoreFieldNorm: true,
-  threshold: 0.78,
-  keys: ['id'],
-}
-
-export function runsearch(query: string, files: SearchList): SearchList {
-  const fuse = new Fuse(files, options)
-  const tmp = fuse.search(query)
-
-  return tmp.map((result) => result.item)
-}
 
 // function removeDuplicateCharacters(combinedQuery: string): string {
 //   return Array.from(new Set(nodejieba.cut(combinedQuery, true))).join('')

--- a/algorithm/search_core.ts
+++ b/algorithm/search_core.ts
@@ -1,0 +1,78 @@
+import Fuse, { IFuseOptions } from 'fuse.js'
+import * as OpenCC from 'opencc-js'
+
+import { search_index } from "@/config/root"
+import { SearchItem, SearchList } from '@/types'
+
+export const cn2jp = OpenCC.Converter({ from: 'cn', to: 'jp' })
+
+export const fuseOptions: IFuseOptions<SearchItem> = {
+  includeScore: true,
+  ignoreLocation: true,
+  ignoreFieldNorm: true,
+  threshold: 0.78,
+  keys: ['id'],
+}
+
+export function runsearch(query: string, files: SearchList): SearchList {
+  const fuse = new Fuse(files, fuseOptions)
+  return fuse.search(query).map((result) => result.item)
+}
+
+export async function aiSearchCore(
+  q: string,
+  n: number,
+  index: SearchList = search_index,
+): Promise<SearchItem[]> {
+  const queryjp = cn2jp(q)
+  const queryai = await fetch(
+    `http://localhost:2998/findname?name=${encodeURIComponent(q)}`,
+  )
+    .then((res) => res.json())
+    .then((data) => data.ans[0] || '')
+    .catch(() => '')
+
+  const fuse = new Fuse(index, fuseOptions)
+  const aiRes = fuse
+    .search(`${q} ${queryai}`)
+    .map((result) => ({ item: result.item, score: result.score }))
+  const traditionalResults = fuse
+    .search(`${q} ${queryjp}`)
+    .map((result) => ({ item: result.item, score: result.score }))
+
+  const results: Array<{ item: SearchItem; score: number | undefined }> = []
+  for (const res of aiRes) {
+    if (res.score) {
+      results.push(res)
+    }
+  }
+  for (const res of traditionalResults) {
+    if (res.score) {
+      const existingIndex = results.findIndex(
+        (r) => r.item.id === res.item.id,
+      )
+      if (existingIndex !== -1) {
+        if (results[existingIndex].score && res.score) {
+          results[existingIndex].score =
+            (results[existingIndex].score ?? 0) / 2 + (res.score ?? 0) / 2
+        }
+      } else {
+        results.push(res)
+      }
+    }
+  }
+
+  return results
+    .sort((a, b) => (a.score ?? 0) - (b.score ?? 0))
+    .slice(0, n)
+    .map((result) => result.item)
+}
+
+export function defaultSearchCore(
+  q: string,
+  n: number,
+  index: SearchList = search_index,
+): SearchItem[] {
+  const queryjp = cn2jp(q)
+  return runsearch(`${q}${queryjp}`, index).slice(0, n)
+}


### PR DESCRIPTION
## Summary
- extract search helpers into `search_core.ts`
- reuse shared search code in worker and main search module

## Testing
- `npm run lint` *(fails: Module needs import attribute)*

------
https://chatgpt.com/codex/tasks/task_e_683dfab1d4288320bad0b88f9aea8eb6