### PR TITLE
Fix worker paths

### DIFF
--- a/algorithm/ai_search_worker.ts
+++ b/algorithm/ai_search_worker.ts
@@ -1,5 +1,5 @@
-import { parentPort } from 'worker_threads'
-import { search_index } from '@/config/root'
+import { parentPort } from 'node:worker_threads'
+import { search_index } from '../config/root'
 import { aiSearchCore } from './search_core'
 
 parentPort?.on('message', async ({ q, n }: { q: string; n: number }) => {

--- a/algorithm/search.ts
+++ b/algorithm/search.ts
@@ -1,12 +1,12 @@
-import { Worker } from 'worker_threads'
+import { Worker } from 'node:worker_threads'
 import { fileURLToPath } from 'url'
 import { dirname, join } from 'path'
 
 import { trim_file_path } from './url'
 import { cn2jp, runsearch } from './search_core'
 
-import { BucketFiles, SearchItem } from '@/types'
-import { search_index } from '@/config/root'
+import { BucketFiles, SearchItem } from '../types'
+import { search_index } from '../config/root'
 
 // function removeDuplicateCharacters(combinedQuery: string): string {
 //   return Array.from(new Set(nodejieba.cut(combinedQuery, true))).join('')

--- a/algorithm/search_core.ts
+++ b/algorithm/search_core.ts
@@ -1,8 +1,8 @@
 import Fuse, { IFuseOptions } from 'fuse.js'
 import * as OpenCC from 'opencc-js'
 
-import { search_index } from "@/config/root"
-import { SearchItem, SearchList } from '@/types'
+import { search_index } from '../config/root'
+import { SearchItem, SearchList } from '../types'
 
 export const cn2jp = OpenCC.Converter({ from: 'cn', to: 'jp' })
 

--- a/algorithm/tree.ts
+++ b/algorithm/tree.ts
@@ -1,4 +1,4 @@
-import { BucketFiles, Inode, Variety } from '@/types'
+import { BucketFiles, Inode, Variety } from '../types'
 
 export function generateTree(fileList: BucketFiles): any {
   const root: any = {}

--- a/algorithm/url.ts
+++ b/algorithm/url.ts
@@ -1,4 +1,4 @@
-import { GameType, Node } from '@/types'
+import { GameType, Node } from '../types'
 
 export function generateHref(item: Node, slug: string[]) {
   const a = ['', 'files', ...slug, item.name]

--- a/algorithm/wiki.ts
+++ b/algorithm/wiki.ts
@@ -1,7 +1,7 @@
 import Redis from 'ioredis'
 
-import { config } from '@/config/root'
-import { WikipediaAnswer } from '@/types/wiki'
+import { config } from '../config/root'
+import { WikipediaAnswer } from '../types/wiki'
 
 /* eslint-disable no-console */
 export type Lang = 'ja' | 'zh' | 'en'

--- a/config/root.ts
+++ b/config/root.ts
@@ -1,11 +1,11 @@
-import type { BucketFiles, Config, SearchList } from '@/types'
+import type { BucketFiles, Config, SearchList } from '../types'
 
 import fs from 'fs'
 
 import toml from 'toml'
 
-import { generateTree } from '@/algorithm/tree'
-import { aggregate_builder } from '@/algorithm/search'
+import { generateTree } from '../algorithm/tree'
+import { aggregate_builder } from '../algorithm/search'
 
 export const shinnku_bucket_files_json = JSON.parse(
   fs.readFileSync('data/shinnku_bucket_files.json', { encoding: 'utf8' }),


### PR DESCRIPTION
## Notes
- `npm run lint` fails with `ERR_IMPORT_ATTRIBUTE_MISSING`

## Summary
- import worker threads from `node:worker_threads`
- use relative imports instead of tsconfig alias for worker code

## Testing
- `npm run lint` *(fails: ERR_IMPORT_ATTRIBUTE_MISSING)*

------
https://chatgpt.com/codex/tasks/task_e_683e6985099c83208744c59fe7558b07