### PR TITLE
Add color-eyre error handling to backend

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -176,6 +176,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "color-eyre"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5920befb47832a6d61ee3a3a846565cfa39b331331e68a3b1d1116630f2f26d"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8b88ea9df13354b55bc7234ebcce36e6ef896aca2e42a15de9e10edce01b427"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -225,6 +252,16 @@ checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+dependencies = [
+ "indenter",
+ "once_cell",
 ]
 
 [[package]]
@@ -604,6 +641,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+
+[[package]]
 name = "indexmap"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -634,6 +677,12 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -796,6 +845,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "owo-colors"
+version = "4.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26995317201fa17f3656c36716aed4a7c81743a9634ac4c99c0eeda495db0cec"
 
 [[package]]
 name = "parking_lot"
@@ -1105,12 +1160,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shinnku-com-backend"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",
  "chromadb",
+ "color-eyre",
  "serde",
  "serde_json",
  "tokio",
@@ -1231,6 +1296,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1338,6 +1413,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
 ]
 
 [[package]]
@@ -1374,6 +1471,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -10,3 +10,4 @@ serde_json = "1.0.140"
 tokio = { version = "1.45.0", features = ["full"] }
 chromadb = { version = "2.2.2", features = ["openai"] }
 anyhow = "1"
+color-eyre = "0.6"

--- a/backend/src/handlers.rs
+++ b/backend/src/handlers.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use axum::{
     extract::Query,
     http::StatusCode,
@@ -60,9 +61,7 @@ pub async fn find_name(Query(params): Query<NameQuery>) -> impl IntoResponse {
     }
 }
 
-async fn fetch_intro(
-    name: &str,
-) -> Result<Option<String>, Box<dyn std::error::Error + Send + Sync>> {
+async fn fetch_intro(name: &str) -> Result<Option<String>> {
     let client = ChromaClient::new(Default::default()).await?;
     let collection = client
         .get_or_create_collection("beg_rag_chroma_generate", None)
@@ -86,9 +85,7 @@ async fn fetch_intro(
         .and_then(|mut v| v.pop()))
 }
 
-async fn fetch_findname(
-    name: &str,
-) -> Result<Vec<String>, Box<dyn std::error::Error + Send + Sync>> {
+async fn fetch_findname(name: &str) -> Result<Vec<String>> {
     let client = ChromaClient::new(Default::default()).await?;
     let collection = client
         .get_or_create_collection("beg_rag_chroma", None)

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use axum::{Router, routing::get};
 
 mod data;
@@ -6,14 +7,16 @@ mod handlers;
 use handlers::{find_name, intro};
 
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<()> {
+    color_eyre::install().expect("Failed to install error reporting");
+
     let app = Router::new()
         .route("/intro", get(intro))
         .route("/findname", get(find_name));
 
-    let listener = tokio::net::TcpListener::bind(("127.0.0.1", 2998))
-        .await
-        .unwrap();
-    println!("Listening on {}", listener.local_addr().unwrap());
-    axum::serve(listener, app).await.unwrap();
+    let listener = tokio::net::TcpListener::bind(("127.0.0.1", 2998)).await?;
+    let addr = listener.local_addr()?;
+    println!("Listening on {}", addr);
+    axum::serve(listener, app).await?;
+    Ok(())
 }


### PR DESCRIPTION
## Summary
- add `color-eyre` to backend dependencies
- use `anyhow::Result` and initialize `color_eyre` in `main`
- refactor handler helpers to return `anyhow::Result`

## Testing
- `cargo fmt && cargo check`
- `pnpm run format`
- `pnpm run lint`


------
https://chatgpt.com/codex/tasks/task_e_683ff6ab23c883209a75e145dc5ed2bb