### PR TITLE
Fix Rust handler compile errors

### DIFF
--- a/backend/src/handlers.rs
+++ b/backend/src/handlers.rs
@@ -8,22 +8,21 @@ use serde::Deserialize;
 use serde_json::json;
 
 use once_cell::sync::OnceCell;
+use pyo3::ffi::c_str;
 use pyo3::{prelude::*, types::PyDict};
 use pyo3_async_runtimes::tokio::into_future;
+use std::ffi::CString;
 
 static PY_RETRIEVER_INTRO: OnceCell<Py<PyAny>> = OnceCell::new();
 static PY_RETRIEVER_FINDNAME: OnceCell<Py<PyAny>> = OnceCell::new();
 
 pub fn init_py() -> PyResult<()> {
     Python::with_gil(|py| {
-        let module = PyModule::from_code(
-            py,
-            include_str!("../../ai/preload.py"),
-            "preload.py",
-            "preload",
-        )?;
-        let intro = module.getattr("retriever_intro")?.into_py(py);
-        let findname = module.getattr("retriever_findname")?.into_py(py);
+        let code = CString::new(include_str!("../../ai/preload.py"))?;
+        let module =
+            PyModule::from_code(py, code.as_c_str(), c_str!("preload.py"), c_str!("preload"))?;
+        let intro = module.getattr("retriever_intro")?.unbind();
+        let findname = module.getattr("retriever_findname")?.unbind();
         PY_RETRIEVER_INTRO.set(intro).ok();
         PY_RETRIEVER_FINDNAME.set(findname).ok();
         Ok(())
@@ -83,29 +82,30 @@ async fn fetch_intro(name: &str) -> Result<Option<String>> {
         let retriever = PY_RETRIEVER_INTRO
             .get()
             .expect("python not initialized")
-            .as_ref(py);
+            .bind(py);
         let kwargs = PyDict::new(py);
         kwargs.set_item("k", 1)?;
-        let awaitable = retriever.call_method("ainvoke", (name,), Some(kwargs))?;
+        let awaitable = retriever.call_method("ainvoke", (name,), Some(&kwargs))?;
         into_future(awaitable)
     })?;
 
     let obj = fut.await?;
     let content = Python::with_gil(|py| -> PyResult<Option<String>> {
-        if obj.is_none(py) {
+        let obj = obj.bind(py);
+        if obj.is_none() {
             return Ok(None);
         }
-        if let Ok(v) = obj.as_ref(py).getattr("page_content") {
+        if let Ok(v) = obj.getattr("page_content") {
             return v.extract().map(Some);
         }
-        if let Ok(list) = obj.as_ref(py).downcast::<pyo3::types::PyList>() {
+        if let Ok(list) = obj.downcast::<pyo3::types::PyList>() {
             if let Some(item) = list.iter().next() {
                 if let Ok(v) = item.getattr("page_content") {
                     return v.extract().map(Some);
                 }
             }
         }
-        Ok(Some(obj.as_ref(py).str()?.to_str()?.to_string()))
+        Ok(Some(obj.str()?.to_str()?.to_string()))
     })?;
     Ok(content)
 }
@@ -115,16 +115,17 @@ async fn fetch_findname(name: &str) -> Result<Vec<String>> {
         let retriever = PY_RETRIEVER_FINDNAME
             .get()
             .expect("python not initialized")
-            .as_ref(py);
+            .bind(py);
         let kwargs = PyDict::new(py);
         kwargs.set_item("k", 12)?;
-        let awaitable = retriever.call_method("ainvoke", (name,), Some(kwargs))?;
+        let awaitable = retriever.call_method("ainvoke", (name,), Some(&kwargs))?;
         into_future(awaitable)
     })?;
 
     let obj = fut.await?;
     let list = Python::with_gil(|py| -> PyResult<Vec<String>> {
-        if let Ok(pylist) = obj.as_ref(py).downcast::<pyo3::types::PyList>() {
+        let obj = obj.bind(py);
+        if let Ok(pylist) = obj.downcast::<pyo3::types::PyList>() {
             Ok(pylist
                 .iter()
                 .filter_map(|item| {
@@ -135,12 +136,12 @@ async fn fetch_findname(name: &str) -> Result<Vec<String>> {
                     }
                 })
                 .collect())
-        } else if let Ok(v) = obj.as_ref(py).getattr("page_content") {
+        } else if let Ok(v) = obj.getattr("page_content") {
             Ok(vec![v.extract::<String>()?])
-        } else if obj.is_none(py) {
+        } else if obj.is_none() {
             Ok(vec![])
         } else {
-            Ok(vec![obj.as_ref(py).str()?.to_str()?.to_string()])
+            Ok(vec![obj.str()?.to_str()?.to_string()])
         }
     })?;
     Ok(list)


### PR DESCRIPTION
## Summary
- update PyO3 API usage in `handlers.rs`
- initialize python module using `CString`
- adjust calls to `call_method` and async retriever functions

## Testing
- `pnpm run format`
- `pnpm run lint`
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68403c876180832094b74bf4e2bd7e68