### PR TITLE
Use virtualenv python in backend

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -707,12 +707,14 @@ dependencies = [
  "anyhow",
  "axum",
  "color-eyre",
+ "libc",
  "once_cell",
  "pyo3",
  "pyo3-async-runtimes",
  "serde",
  "serde_json",
  "tokio",
+ "widestring",
 ]
 
 [[package]]
@@ -904,6 +906,12 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "widestring"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd7cf3379ca1aac9eea11fba24fd7e315d621f8dfe35c8d7d2be8b793726e07d"
 
 [[package]]
 name = "windows-sys"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -13,3 +13,5 @@ pyo3-async-runtimes = { version = "0.25.0", features = ["tokio-runtime"] }
 once_cell = "1"
 anyhow = "1"
 color-eyre = "0.6"
+widestring = "1.2"
+libc = "0.2"

--- a/backend/src/handlers.rs
+++ b/backend/src/handlers.rs
@@ -8,13 +8,39 @@ use serde::Deserialize;
 use serde_json::json;
 
 use once_cell::sync::OnceCell;
-use pyo3::ffi::c_str;
+use pyo3::ffi::{self, c_str};
 use pyo3::{prelude::*, types::PyDict};
 use pyo3_async_runtimes::tokio::into_future;
 use std::ffi::CString;
+use widestring::WideCString;
 
 static PY_RETRIEVER_INTRO: OnceCell<Py<PyAny>> = OnceCell::new();
 static PY_RETRIEVER_FINDNAME: OnceCell<Py<PyAny>> = OnceCell::new();
+
+pub fn configure_python() -> Result<()> {
+    let base = std::env::current_dir()?.join(".venv");
+    let exe_path = base.join("bin/python3").canonicalize()?;
+    let home_path = base.canonicalize()?;
+
+    unsafe {
+        let exe = WideCString::from_str(
+            exe_path
+                .to_str()
+                .ok_or_else(|| anyhow::anyhow!("invalid exe path"))?,
+        )?;
+        let home = WideCString::from_str(
+            home_path
+                .to_str()
+                .ok_or_else(|| anyhow::anyhow!("invalid home path"))?,
+        )?;
+        ffi::Py_SetProgramName(exe.as_ptr() as *const libc::wchar_t);
+        ffi::Py_SetPythonHome(home.as_ptr() as *const libc::wchar_t);
+    }
+
+    // Initialize the interpreter using the configured paths
+    pyo3::prepare_freethreaded_python();
+    Ok(())
+}
 
 pub fn init_py() -> PyResult<()> {
     Python::with_gil(|py| {

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -9,6 +9,7 @@ use handlers::{find_name, intro};
 #[tokio::main]
 async fn main() -> Result<()> {
     color_eyre::install().expect("Failed to install error reporting");
+    handlers::configure_python().expect("failed to configure python");
     handlers::init_py().expect("failed to init python");
 
     let app = Router::new()


### PR DESCRIPTION
## Summary
- allow configuring Python interpreter via `.venv/bin/python3`
- initialize the interpreter before loading Python modules
- add `widestring` and `libc` deps for FFI helpers

## Testing
- `pnpm run format`
- `pnpm run lint`
- `cargo fmt --manifest-path backend/Cargo.toml`
- `cargo check --manifest-path backend/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68404816ecac832093561fb6d434f468