### PR TITLE
Fix i18n client detection

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,4 +1,5 @@
 import { Metadata, Viewport } from 'next'
+import { cookies } from 'next/headers'
 import { Link } from '@heroui/link'
 import Script from 'next/script'
 import '@/styles/index.css'
@@ -33,8 +34,10 @@ export default function RootLayout({
 }: {
   children: React.ReactNode
 }) {
+  const cookieLocale = cookies().get('NEXT_LOCALE')?.value ?? 'zh-cn'
+
   return (
-    <html suppressHydrationWarning lang='en'>
+    <html suppressHydrationWarning lang={cookieLocale}>
       <head>
         <Script
           async

--- a/frontend/i18n/index.ts
+++ b/frontend/i18n/index.ts
@@ -1,5 +1,3 @@
-import { cookies } from 'next/headers'
-
 import zhCn from './zh-cn'
 import zhTw from './zh-tw'
 import enUs from './en-us'
@@ -10,11 +8,27 @@ const locales = {
   'en-us': enUs,
 } as const
 
-type Locale = keyof typeof locales
+export type Locale = keyof typeof locales
+
+const getLocale = (): Locale => {
+  if (typeof window === 'undefined') {
+    // Server environment; rely on the NEXT_LOCALE cookie if present
+    const { cookies } = require('next/headers') as typeof import('next/headers')
+
+    return (
+      (cookies().get('NEXT_LOCALE')?.value as Locale | undefined) ?? 'zh-cn'
+    )
+  }
+
+  // Client environment; fall back to <html lang="..."> attribute
+  const lang = document.documentElement.lang
+
+  return (lang as Locale) || 'zh-cn'
+}
 
 export const t = (key: keyof typeof zhCn) => {
-  const cookieLocale = cookies().get('NEXT_LOCALE')?.value as Locale | undefined
-  const messages = locales[cookieLocale ?? 'zh-cn']
+  const locale = getLocale()
+  const messages = locales[locale]
 
   return messages[key] ?? zhCn[key]
 }


### PR DESCRIPTION
## Summary
- export `Locale` type and detect the client locale using `<html lang>`
- set the `<html>` `lang` attribute from the `NEXT_LOCALE` cookie

## Testing
- `pnpm run format`
- `pnpm run lint`
- `cargo fmt`
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68404802cce88320937d20ea60230d34