### PR TITLE
Update Python initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,22 @@ pnpm run dev
 Open your browser and navigate to `http://localhost:3000` to see the app in
 action.
 
+### Backend Setup
+
+Create a Python virtual environment and install the backend dependencies:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+Build and run the Rust backend using this interpreter:
+
+```bash
+PYO3_PYTHON=./.venv/bin/python cargo run
+```
+
 ## Internationalization
 
 Next.js i18n routing generates localized paths for `zh-cn`, `zh-tw`, and `en-us`. The default locale is Simplified Chinese.

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -714,7 +714,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "widestring",
 ]
 
 [[package]]
@@ -906,12 +905,6 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "widestring"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd7cf3379ca1aac9eea11fba24fd7e315d621f8dfe35c8d7d2be8b793726e07d"
 
 [[package]]
 name = "windows-sys"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -13,5 +13,4 @@ pyo3-async-runtimes = { version = "0.25.0", features = ["tokio-runtime"] }
 once_cell = "1"
 anyhow = "1"
 color-eyre = "0.6"
-widestring = "1.2"
 libc = "0.2"


### PR DESCRIPTION
## Summary
- switch backend Python initialization to `PyConfig`
- document backend Python setup in `README`
- remove unused widestring dependency

## Testing
- `cargo fmt --all`
- `PYO3_PYTHON=$(pwd)/../.venv/bin/python cargo check` *(fails: could not find `config` in `pyo3`)*
- `PYO3_PYTHON=$(pwd)/../.venv/bin/python cargo run` *(fails: could not find `config` in `pyo3`)*

------
https://chatgpt.com/codex/tasks/task_e_68405715344c8320b4b1bfbc72af3f40