### PR TITLE
Fix PyO3 initialization and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,13 @@ Create a Python virtual environment and install the backend dependencies:
 python3 -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
+
+# Build the Rust backend using the Python from this virtual environment
+export PYO3_PYTHON=$(pwd)/.venv/bin/python3
+cargo run -p shinnku-com-backend
+
+# Do not set PYTHONHOME manually; the backend will read `pyvenv.cfg`
+# to find the standard library when embedding Python.
 ```
 
 ## Internationalization

--- a/backend/src/handlers.rs
+++ b/backend/src/handlers.rs
@@ -20,21 +20,19 @@ pub fn configure_python() -> Result<()> {
     let base = std::env::current_dir()?.join("..").join(".venv");
     println!("Configuring Python environment... {}", base.display());
     let exe_path = base.join("bin/python3").canonicalize()?;
-    let home_path = base.canonicalize()?;
 
     let exe = exe_path
         .to_str()
         .ok_or_else(|| anyhow::anyhow!("invalid exe path"))?
         .to_string();
-    let home = home_path
-        .to_str()
-        .ok_or_else(|| anyhow::anyhow!("invalid home path"))?
-        .to_string();
 
+    // Only point PyO3 at the virtual environment's Python executable.
+    // Avoid setting PYTHONHOME or PYTHONPATH so the interpreter can
+    // resolve the standard library from the base installation.
+    // Setting environment variables mutates global process state which is
+    // marked `unsafe` in recent Rust versions.
     unsafe {
         std::env::set_var("PYTHONEXECUTABLE", &exe);
-        std::env::set_var("PYTHONHOME", &home);
-        std::env::set_var("PYTHONPATH", &exe);
     }
 
     pyo3::prepare_freethreaded_python();


### PR DESCRIPTION
## Summary
- adjust Python initialization so PyO3 works with a venv
- update backend setup instructions with PYO3_PYTHON

## Testing
- `pnpm run format`
- `pnpm run lint` *(fails: <html> elements must have the lang prop)*
- `cargo fmt`
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_68405ee9f2f0832080dcc4cb8609d898