### PR TITLE
Adjust background opacity

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -9,6 +9,7 @@ import { cn } from '@/utils/cn'
 import { siteConfig } from '@/config/site'
 import { fontSans } from '@/config/fonts'
 import { Navbar } from '@/components/navbar'
+import { BackgroundBox } from '@/components/background-box'
 
 export const metadata: Metadata = {
   title: {
@@ -60,10 +61,7 @@ export default function RootLayout({
           fontSans.variable,
         )}
       >
-        <div
-          className="box bg-[url('/assets/GT5Bjdba4AAbCkU.jpeg')] md:bg-[url('/assets/81320307_p0.jpg')]"
-          id='box-main'
-        />
+        <BackgroundBox />
         <Providers themeProps={{ attribute: 'class', defaultTheme: 'dark' }}>
           <div className='relative flex h-screen flex-col'>
             <Navbar />

--- a/frontend/components/background-box.tsx
+++ b/frontend/components/background-box.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
+
+export const BackgroundBox = () => {
+  const pathname = usePathname()
+  const isHome = pathname === '/'
+
+  return (
+    <div
+      className="box bg-[url('/assets/GT5Bjdba4AAbCkU.jpeg')] md:bg-[url('/assets/81320307_p0.jpg')]"
+      id='box-main'
+      style={{ opacity: isHome ? 0.24 : 0.08 }}
+    />
+  )
+}

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -23,7 +23,7 @@
   background-repeat: no-repeat;
   background-position: center;
   background-size: cover;
-  opacity: 0.24;
+  opacity: 0.08;
   vertical-align: middle;
   border-style: none;
 }


### PR DESCRIPTION
## Summary
- lower `.box` opacity for non-home pages
- add a `BackgroundBox` component to toggle opacity based on the route

## Testing
- `pnpm run format`
- `pnpm run lint`
- `cargo fmt` *(fails: `cargo-fmt` not installed)*
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_684c56dba1088320af894a78a4984368