### PR TITLE
Initialize root data via tokio OnceCell

### DIFF
--- a/backend/src/alg/mod.rs
+++ b/backend/src/alg/mod.rs
@@ -1,2 +1,2 @@
-mod root;
+pub mod root;
 mod search;

--- a/backend/src/alg/root.rs
+++ b/backend/src/alg/root.rs
@@ -1,7 +1,7 @@
 use crate::alg::search::{SearchList, aggregate_builder};
 use crate::config::{BucketFiles, NodeValue, TreeNode};
 use anyhow::Result;
-use tokio::fs;
+use tokio::{fs, sync::OnceCell};
 
 /// Generate a hierarchical tree from a flat list of files.
 pub fn generate_tree(file_list: &BucketFiles) -> TreeNode {
@@ -37,6 +37,17 @@ pub struct Root {
     pub shinnku_tree: TreeNode,
     pub galgame0_tree: TreeNode,
     pub search_index: SearchList,
+}
+
+static ROOT_CELL: OnceCell<Root> = OnceCell::const_new();
+
+async fn init_root() -> Root {
+    load_root().await.expect("failed to load root data")
+}
+
+/// Retrieve the global [`Root`] instance, loading it on first access.
+pub async fn get_root() -> &'static Root {
+    ROOT_CELL.get_or_init(init_root).await
 }
 
 /// Construct the combined tree used by the frontend.

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -3,6 +3,7 @@ mod config;
 mod fuse;
 mod handlers;
 
+use alg::root::get_root;
 use anyhow::Result;
 use axum::{Router, routing::get};
 use handlers::{find_name, intro};
@@ -10,6 +11,7 @@ use handlers::{find_name, intro};
 #[tokio::main]
 async fn main() -> Result<()> {
     config::get_redis().await;
+    get_root().await;
     color_eyre::install().expect("Failed to install error reporting");
 
     let app = Router::new()


### PR DESCRIPTION
## Summary
- expose `alg::root` module publicly
- store the generated `Root` struct in a `OnceCell`
- load this data on startup in `main`

## Testing
- `cargo fmt`
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_6854e799d1c883208b5900f1baf85898