### PR TITLE
Add inode backend route

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1317,6 +1317,7 @@ dependencies = [
  "axum",
  "color-eyre",
  "crossbeam-utils",
+ "percent-encoding",
  "rayon",
  "redis",
  "reqwest",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -11,6 +11,7 @@ tokio = { version = "1.45.0", features = ["full"] }
 reqwest = { version = "0.12.19", features = ["json"] }
 anyhow = "1"
 color-eyre = "0.6"
+percent-encoding = "2"
 redis = { version = "0.32", features = [
     "tokio-comp",
     "cluster-async",

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -6,7 +6,7 @@ mod handlers;
 use alg::root::get_root;
 use anyhow::Result;
 use axum::{Router, routing::get};
-use handlers::{find_name, intro};
+use handlers::{find_name, inode, intro};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -16,7 +16,8 @@ async fn main() -> Result<()> {
 
     let app = Router::new()
         .route("/intro", get(intro))
-        .route("/findname", get(find_name));
+        .route("/findname", get(find_name))
+        .route("/files/*path", get(inode));
 
     let listener = tokio::net::TcpListener::bind(("127.0.0.1", 2999)).await?;
     let addr = listener.local_addr()?;


### PR DESCRIPTION
## Summary
- implement `/files/*path` to return directory info
- expose new handler in router
- include percent-encoding crate for path decoding

## Testing
- `cargo fmt --all`
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_6854ea15041c832081a33ce348d7e103