### PR TITLE
Add search endpoint

### DIFF
--- a/backend/src/alg/mod.rs
+++ b/backend/src/alg/mod.rs
@@ -1,2 +1,2 @@
 pub mod root;
-mod search;
+pub mod search;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -5,7 +5,7 @@ mod handlers;
 
 use anyhow::Result;
 use axum::{Router, routing::get};
-use handlers::{find_name, inode, inode_root, intro};
+use handlers::{find_name, inode, inode_root, intro, search};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -17,6 +17,7 @@ async fn main() -> Result<()> {
     let app = Router::new()
         .route("/intro", get(intro))
         .route("/findname", get(find_name))
+        .route("/search", get(search))
         .route("/files", get(inode_root))
         .route("/files/{*path}", get(inode));
 


### PR DESCRIPTION
## Summary
- expose `search` module
- implement `/search` handler to run fuzzy search on `search_index`
- add routing to `/search` in backend

## Testing
- `cargo fmt`
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_6855040112608320bb6b0112ddae0c81