### PR TITLE
Add combine search API

### DIFF
--- a/backend/src/handlers.rs
+++ b/backend/src/handlers.rs
@@ -1,4 +1,7 @@
-use crate::alg::{root, search::runsearch};
+use crate::alg::{
+    root,
+    search::{combine_search, runsearch},
+};
 use crate::config::{FileInfo, NodeValue, TreeNode};
 use axum::{
     Json,
@@ -17,6 +20,13 @@ pub struct NameQuery {
 #[derive(Deserialize)]
 pub struct SearchQuery {
     pub q: Option<String>,
+    pub n: Option<usize>,
+}
+
+#[derive(Deserialize)]
+pub struct CombineSearchQuery {
+    pub q1: Option<String>,
+    pub q2: Option<String>,
     pub n: Option<usize>,
 }
 
@@ -136,4 +146,16 @@ pub async fn search(Query(params): Query<SearchQuery>) -> impl IntoResponse {
     let results = runsearch(&q, search_index);
     let sliced: Vec<_> = results.into_iter().take(n).collect();
     (StatusCode::OK, Json(sliced)).into_response()
+}
+
+pub async fn conbine_search(Query(params): Query<CombineSearchQuery>) -> impl IntoResponse {
+    let (q1, q2) = match (params.q1, params.q2) {
+        (Some(q1), Some(q2)) => (q1, q2),
+        _ => return StatusCode::BAD_REQUEST.into_response(),
+    };
+
+    let search_index = &root::get_root().await.search_index;
+    let n = params.n.unwrap_or(100);
+    let results = combine_search(&q1, &q2, n, search_index);
+    (StatusCode::OK, Json(results)).into_response()
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -5,7 +5,7 @@ mod handlers;
 
 use anyhow::Result;
 use axum::{Router, routing::get};
-use handlers::{find_name, inode, inode_root, intro, search};
+use handlers::{conbine_search, find_name, inode, inode_root, intro, search};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -18,6 +18,7 @@ async fn main() -> Result<()> {
         .route("/intro", get(intro))
         .route("/findname", get(find_name))
         .route("/search", get(search))
+        .route("/conbinesearch", get(conbine_search))
         .route("/files", get(inode_root))
         .route("/files/{*path}", get(inode));
 


### PR DESCRIPTION
## Summary
- implement `conbine_search` handler for searching by two queries
- expose `/conbinesearch` route in backend

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm run format`
- `pnpm run lint`
- `cargo fmt --manifest-path backend/Cargo.toml`
- `cargo check --manifest-path backend/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_68550c3ac39083208b5a99739a725e03