### PR TITLE
Refactor ai_search to use backend combine search

### DIFF
--- a/frontend/app/api/aiintro/route.ts
+++ b/frontend/app/api/aiintro/route.ts
@@ -6,7 +6,8 @@ export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url)
   const name = searchParams.get('name') as string
   const bg = await wikisearchpicture(name)
-  const intro = await fetch(`http://localhost:2999/intro?name=${name}`)
+  const serviceUrl = process.env.BACKEND_URL || 'http://localhost:2999'
+  const intro = await fetch(`${serviceUrl}/intro?name=${name}`)
 
   if (intro.ok) {
     const text = await intro.text()

--- a/frontend/app/files/[...slug]/page.tsx
+++ b/frontend/app/files/[...slug]/page.tsx
@@ -29,7 +29,8 @@ export default async function BrowserPage({
   const encoded = slug.map(encodeURIComponent).join('/')
   const path = encoded ? `/files/${encoded}` : '/files'
 
-  const res = await fetch(`http://localhost:2999${path}`)
+  const serviceUrl = process.env.BACKEND_URL || 'http://localhost:2999'
+  const res = await fetch(`${serviceUrl}${path}`)
 
   if (!res.ok) {
     notFound()


### PR DESCRIPTION
## Summary
- use Rust backend `/conbinesearch` endpoint for `ai_search`
- fetch data through `BACKEND_URL` env var in browser and API routes

## Testing
- `pnpm run format`
- `pnpm run lint`
- `cargo fmt`
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_685512253edc8320ade497d83687116c