### PR TITLE
Remove Fuse.js and call Rust backend for search

### DIFF
--- a/frontend/algorithm/search.ts
+++ b/frontend/algorithm/search.ts
@@ -1,29 +1,12 @@
-import Fuse, { IFuseOptions } from 'fuse.js'
 import * as OpenCC from 'opencc-js'
 
 import { trim_file_path } from './url'
 
-import { BucketFiles, SearchItem, SearchList } from '@/types'
-import { search_index } from '@/config/root'
+import { BucketFiles, SearchItem } from '@/types'
 
 // export const cn2tw = OpenCC.Converter({ from: 'cn', to: 'tw' })
 // export const tw2cn = OpenCC.Converter({ from: 'tw', to: 'cn' })
 export const cn2jp = OpenCC.Converter({ from: 'cn', to: 'jp' })
-
-const options: IFuseOptions<SearchItem> = {
-  includeScore: true,
-  ignoreLocation: true,
-  ignoreFieldNorm: true,
-  threshold: 0.78,
-  keys: ['id'],
-}
-
-export function runsearch(query: string, files: SearchList): SearchList {
-  const fuse = new Fuse(files, options)
-  const tmp = fuse.search(query)
-
-  return tmp.map((result) => result.item)
-}
 
 // function removeDuplicateCharacters(combinedQuery: string): string {
 //   return Array.from(new Set(nodejieba.cut(combinedQuery, true))).join('')
@@ -59,11 +42,18 @@ export async function ai_search(q: string, n: number): Promise<SearchItem[]> {
   return results
 }
 
-export function default_search(q: string, n: number): SearchItem[] {
+export async function default_search(
+  q: string,
+  n: number,
+): Promise<SearchItem[]> {
   const queryjp = cn2jp(q)
-  // const query = removeDuplicateCharacters(q + queryjp)
+  const serviceUrl = process.env.BACKEND_URL || 'http://localhost:2999'
 
-  const results = runsearch(q + queryjp, search_index).slice(0, n)
+  const results: SearchItem[] = await fetch(
+    `${serviceUrl}/search?q=${encodeURIComponent(q + ' ' + queryjp)}&n=${n}`,
+  )
+    .then((res) => res.json())
+    .catch(() => [])
 
   return results
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,7 +30,6 @@
     "clsx": "2.1.1",
     "dayjs": "^1.11.13",
     "framer-motion": "11.13.1",
-    "fuse.js": "^7.1.0",
     "gray-matter": "^4.0.3",
     "intl-messageformat": "^10.7.16",
     "ioredis": "^5.6.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -68,9 +68,6 @@ importers:
       framer-motion:
         specifier: 11.13.1
         version: 11.13.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      fuse.js:
-        specifier: ^7.1.0
-        version: 7.1.0
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
@@ -2875,10 +2872,6 @@ packages:
 
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
-
-  fuse.js@7.1.0:
-    resolution: {integrity: sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==}
-    engines: {node: '>=10'}
 
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
@@ -8173,8 +8166,6 @@ snapshots:
       is-callable: 1.2.7
 
   functions-have-names@1.2.3: {}
-
-  fuse.js@7.1.0: {}
 
   get-intrinsic@1.3.0:
     dependencies:


### PR DESCRIPTION
## Summary
- switch `default_search` to fetch results from the Rust backend
- drop `fuse.js` dependency

## Testing
- `pnpm run format`
- `pnpm run lint`
- `cargo check` *(fails: `cargo-fmt` missing)*

------
https://chatgpt.com/codex/tasks/task_e_685513fa83848320b2f40515f89c36a4