### PR TITLE
Add wikisearchpicture endpoint in Rust

### DIFF
--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -1,7 +1,9 @@
 pub mod inode;
 pub mod intro;
 pub mod search;
+pub mod wiki;
 
 pub use inode::{inode, inode_root};
 pub use intro::{find_name, intro};
 pub use search::{combine_search_query, search};
+pub use wiki::wikisearchpicture;

--- a/backend/src/handlers/wiki.rs
+++ b/backend/src/handlers/wiki.rs
@@ -1,0 +1,45 @@
+use crate::config::get_redis;
+use axum::{Json, extract::Query, http::StatusCode, response::IntoResponse};
+use redis::aio::ConnectionManager;
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+pub struct WikiPictureQuery {
+    pub name: Option<String>,
+}
+
+#[derive(serde::Serialize)]
+pub struct WikiPictureResponse {
+    pub bg: Option<String>,
+}
+
+pub async fn wikisearchpicture(Query(params): Query<WikiPictureQuery>) -> impl IntoResponse {
+    let name = match params.name {
+        Some(n) => n,
+        None => return StatusCode::BAD_REQUEST.into_response(),
+    };
+
+    let conn = get_redis().await;
+    let mut con: ConnectionManager = conn.clone();
+
+    let key_search = format!("cache:search:wiki:zh:{}", name);
+    let pageid: Option<String> = redis::cmd("GET")
+        .arg(&key_search)
+        .query_async::<Option<String>>(&mut con)
+        .await
+        .ok()
+        .flatten();
+
+    if let Some(pageid) = pageid {
+        let key_img = format!("img:wiki:zh:{}", pageid);
+        if let Ok(bg) = redis::cmd("GET")
+            .arg(&key_img)
+            .query_async::<Option<String>>(&mut con)
+            .await
+        {
+            return (StatusCode::OK, Json(WikiPictureResponse { bg })).into_response();
+        }
+    }
+
+    (StatusCode::OK, Json(WikiPictureResponse { bg: None })).into_response()
+}

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -5,7 +5,9 @@ mod handlers;
 
 use anyhow::Result;
 use axum::{Router, routing::get};
-use handlers::{combine_search_query, find_name, inode, inode_root, intro, search};
+use handlers::{
+    combine_search_query, find_name, inode, inode_root, intro, search, wikisearchpicture,
+};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -19,6 +21,7 @@ async fn main() -> Result<()> {
         .route("/findname", get(find_name))
         .route("/search", get(search))
         .route("/conbinesearch", get(combine_search_query))
+        .route("/wikisearchpicture", get(wikisearchpicture))
         .route("/files", get(inode_root))
         .route("/files/{*path}", get(inode));
 

--- a/frontend/app/api/aiintro/route.ts
+++ b/frontend/app/api/aiintro/route.ts
@@ -1,12 +1,13 @@
 import { NextResponse, NextRequest } from 'next/server'
 
-import { wikisearchpicture } from '@/algorithm/wiki'
-
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url)
   const name = searchParams.get('name') as string
-  const bg = await wikisearchpicture(name)
   const serviceUrl = process.env.BACKEND_URL || 'http://localhost:2999'
+  const bg = await fetch(`${serviceUrl}/wikisearchpicture?name=${name}`)
+    .then((res) => res.json())
+    .then((data) => data.bg as string | null)
+    .catch(() => null)
   const intro = await fetch(`${serviceUrl}/intro?name=${name}`)
 
   if (intro.ok) {


### PR DESCRIPTION
## Summary
- add `wikisearchpicture` handler to backend
- expose `/wikisearchpicture` route
- query the endpoint from the AI intro API route

## Testing
- `cargo check`
- `pnpm run format`
- `pnpm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68551f97ba4c8320847ba9813ee1c906