### PR TITLE
Add search page loading bar

### DIFF
--- a/frontend/app/search/loading.tsx
+++ b/frontend/app/search/loading.tsx
@@ -1,0 +1,9 @@
+'use client'
+
+export default function Loading() {
+  return (
+    <div className='w-full p-4'>
+      <div className='h-1 w-full animate-pulse rounded bg-primary' />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- show a progress bar while search results load

## Testing
- `pnpm run format`
- `pnpm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68552bb1abf8832098f5caa76c24c380