### PR TITLE
Fix search progress bar

### DIFF
--- a/frontend/app/providers.tsx
+++ b/frontend/app/providers.tsx
@@ -4,7 +4,7 @@ import type { ThemeProviderProps } from 'next-themes'
 
 import * as React from 'react'
 import { HeroUIProvider } from '@heroui/system'
-import { useRouter } from 'next/navigation'
+import { useRouter } from '@bprogress/next'
 import { ThemeProvider as NextThemesProvider } from 'next-themes'
 import { AppProgressProvider as ProgressProvider } from '@bprogress/next'
 

--- a/frontend/components/blog/SideTreeItem.tsx
+++ b/frontend/components/blog/SideTreeItem.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react'
 import { Link } from '@heroui/link'
 import { ChevronRight, FileText, FolderOpen } from 'lucide-react'
-import { useRouter } from 'next/navigation'
+import { useRouter } from '@bprogress/next'
 
 import { BlogTreeNode } from '@/lib/mdx/types'
 import { cn } from '@/utils/cn'

--- a/frontend/components/files/returnButton.tsx
+++ b/frontend/components/files/returnButton.tsx
@@ -2,7 +2,7 @@
 
 import { ArrowLeftOutlined } from '@ant-design/icons'
 import { Button, Link } from '@heroui/react'
-import { useRouter } from 'next/navigation'
+import { useRouter } from '@bprogress/next'
 
 interface RoundArrowButtonProps {
   ariaLabel?: string

--- a/frontend/components/search/index.tsx
+++ b/frontend/components/search/index.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import React, { useState } from 'react'
-import { useRouter } from 'next/navigation'
+import { useRouter } from '@bprogress/next'
 import { Input } from '@heroui/input'
 import { Kbd } from '@heroui/kbd'
 


### PR DESCRIPTION
## Summary
- update `useRouter` imports to come from `@bprogress/next`

## Testing
- `pnpm run format`
- `pnpm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68554aab6d588320aa58788a8e83d6f4