### PR TITLE
Add image proxy API

### DIFF
--- a/frontend/app/api/image-proxy/route.ts
+++ b/frontend/app/api/image-proxy/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest } from 'next/server'
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url)
+  const path = searchParams.get('path')
+
+  if (!path) {
+    return new Response('Missing path', { status: 400 })
+  }
+
+  const targetUrl = `https://www.shinnku.com/image/${encodeURIComponent(path)}`
+
+  const resp = await fetch(targetUrl, {
+    headers: {
+      Referer: 'https://www.shinnku.com',
+      Origin: 'https://www.shinnku.com',
+    },
+  })
+
+  if (!resp.ok) {
+    return new Response('Failed to fetch image', { status: resp.status })
+  }
+
+  const headers = new Headers(resp.headers)
+  const contentType = resp.headers.get('content-type')
+
+  if (contentType) {
+    headers.set('content-type', contentType)
+  }
+
+  return new Response(resp.body, {
+    status: resp.status,
+    headers,
+  })
+}

--- a/frontend/components/search/intro.tsx
+++ b/frontend/components/search/intro.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
-import { ScrollShadow } from '@heroui/react'
 import remarkBreaks from 'remark-breaks'
 
 import { WikipediaAnswer } from '@/types/wiki'
@@ -24,7 +23,7 @@ export const SearchIntro: React.FC<SearchIntroProps> = ({ name }) => {
     if (intro.bg) {
       const boxMain = document.getElementById('box-main')!
 
-      boxMain.style.backgroundImage = `url('https://www.shinnku.com/image/${intro.bg}')`
+      boxMain.style.backgroundImage = `url('/api/image-proxy?path=${intro.bg}')`
     }
   }, [intro.bg])
 


### PR DESCRIPTION
## Summary
- add `/api/image-proxy` to stream images from shinnku.com
- load search intro background via the new proxy

## Testing
- `pnpm run format`
- `pnpm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6855644ae24c8320a948fa814b9cfdeb