### PR TITLE
Replace unwraps in fuse module

### DIFF
--- a/backend/src/fuse/tests.rs
+++ b/backend/src/fuse/tests.rs
@@ -7,7 +7,9 @@ fn multibyte_chars_indices() {
 
     let fuse = Fuse::default();
     let pat = fuse.create_pattern(needle);
-    let x = fuse.search(pat.as_ref(), s).unwrap();
+    let x = fuse
+        .search(pat.as_ref(), s)
+        .expect("search should return a result");
     let r = &x.ranges[0];
 
     assert_eq!(&s[r.start..r.end], needle);

--- a/backend/src/fuse/utils.rs
+++ b/backend/src/fuse/utils.rs
@@ -40,7 +40,7 @@ pub fn find_ranges(mask: &[u8]) -> Result<Vec<Range<usize>>, String> {
         }
     }
 
-    if *mask.last().unwrap() == 1 {
+    if mask.last() == Some(&1) {
         ranges.push(start as usize..mask.len())
     }
     Ok(ranges)


### PR DESCRIPTION
## Summary
- remove direct `unwrap()` usage in fuse implementation
- improve range detection logic
- update tests

## Testing
- `cargo check --manifest-path backend/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_68559609df0083209d6a55cbee673a94