### PR TITLE
Fix theme-switch icons visibility

### DIFF
--- a/frontend/components/primitives/theme-switch.tsx
+++ b/frontend/components/primitives/theme-switch.tsx
@@ -30,12 +30,15 @@ export const ThemeSwitch: FC<ThemeSwitchProps> = ({ className }) => {
 
   return (
     <Switch
-      checked={isLight}
-      onCheckedChange={toggleTheme}
       aria-label={`Switch to ${isLight ? 'dark' : 'light'} mode`}
-      className={cn('px-px transition-opacity hover:opacity-80 cursor-pointer', className)}
+      checked={isLight}
+      className={cn(
+        'px-px transition-opacity hover:opacity-80 cursor-pointer',
+        className,
+      )}
+      onCheckedChange={toggleTheme}
     >
-      {isLight ? <SunFilledIcon size={22} /> : <MoonFilledIcon size={22} />}
+      {isLight ? <SunFilledIcon size={16} /> : <MoonFilledIcon size={16} />}
     </Switch>
   )
 }

--- a/frontend/components/ui/switch.tsx
+++ b/frontend/components/ui/switch.tsx
@@ -1,12 +1,12 @@
-import * as React from 'react'
 import * as SwitchPrimitives from '@radix-ui/react-switch'
+import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 
 const Switch = React.forwardRef<
   React.ElementRef<typeof SwitchPrimitives.Root>,
   React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
->(({ className, ...props }, ref) => (
+>(({ className, children, ...props }, ref) => (
   <SwitchPrimitives.Root
     className={cn(
       'peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input',
@@ -15,11 +15,12 @@ const Switch = React.forwardRef<
     {...props}
     ref={ref}
   >
-    <SwitchPrimitives.Thumb
-      className='pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0'
-    />
+    <SwitchPrimitives.Thumb className='pointer-events-none flex h-5 w-5 items-center justify-center rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0'>
+      {children}
+    </SwitchPrimitives.Thumb>
   </SwitchPrimitives.Root>
 ))
+
 Switch.displayName = SwitchPrimitives.Root.displayName
 
 export { Switch }


### PR DESCRIPTION
## Summary
- allow Switch to render children inside thumb
- resize theme-switch icons so they fit the thumb

## Testing
- `pnpm run lint`
- `pnpm build`
- `cargo check`
- `cargo test` *(fails: failed to load root data)*

------
https://chatgpt.com/codex/tasks/task_e_68567df46dc0832082a9c93d0a5b2507