### PR TITLE
Switch return button to shadcn

### DIFF
--- a/frontend/components/files/returnButton.tsx
+++ b/frontend/components/files/returnButton.tsx
@@ -1,8 +1,9 @@
 'use client'
 
-import { ArrowLeftOutlined } from '@ant-design/icons'
 import { useRouter } from '@bprogress/next'
-import { Button, Link } from '@heroui/react'
+import { ArrowLeft } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
 
 interface RoundArrowButtonProps {
   ariaLabel?: string
@@ -15,16 +16,13 @@ export const RoundArrowButton: React.FC<RoundArrowButtonProps> = ({
 
   return (
     <Button
-      isIconOnly
       aria-label={ariaLabel}
-      as={Link}
-      className='absolute bottom-12 left-6'
-      radius='full'
-      size='lg'
-      variant='flat'
-      onPress={() => router.back()}
+      className='absolute bottom-12 left-6 rounded-full'
+      size='icon'
+      variant='secondary'
+      onClick={() => router.back()}
     >
-      <ArrowLeftOutlined aria-hidden='true' className='h-5 w-5' />
+      <ArrowLeft aria-hidden='true' className='size-5' />
     </Button>
   )
 }

--- a/frontend/components/ui/pagination.tsx
+++ b/frontend/components/ui/pagination.tsx
@@ -6,12 +6,13 @@ import { cn } from '@/lib/utils'
 
 const Pagination = ({ className, ...props }: React.ComponentProps<'nav'>) => (
   <nav
-    role='navigation'
     aria-label='pagination'
     className={cn('mx-auto flex w-full justify-center', className)}
+    role='navigation'
     {...props}
   />
 )
+
 Pagination.displayName = 'Pagination'
 
 const PaginationContent = React.forwardRef<
@@ -24,6 +25,7 @@ const PaginationContent = React.forwardRef<
     {...props}
   />
 ))
+
 PaginationContent.displayName = 'PaginationContent'
 
 const PaginationItem = React.forwardRef<
@@ -32,6 +34,7 @@ const PaginationItem = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <li ref={ref} className={cn('', className)} {...props} />
 ))
+
 PaginationItem.displayName = 'PaginationItem'
 
 type PaginationLinkProps = {
@@ -43,6 +46,7 @@ const PaginationLink = ({
   className,
   isActive,
   size = 'icon',
+  children,
   ...props
 }: PaginationLinkProps) => (
   <a
@@ -55,8 +59,11 @@ const PaginationLink = ({
       className,
     )}
     {...props}
-  />
+  >
+    {children}
+  </a>
 )
+
 PaginationLink.displayName = 'PaginationLink'
 
 const PaginationPrevious = ({
@@ -65,14 +72,15 @@ const PaginationPrevious = ({
 }: React.ComponentProps<typeof PaginationLink>) => (
   <PaginationLink
     aria-label='Go to previous page'
-    size='default'
     className={cn('gap-1 pl-2.5', className)}
+    size='default'
     {...props}
   >
     <ChevronLeft className='h-4 w-4' />
     <span>Previous</span>
   </PaginationLink>
 )
+
 PaginationPrevious.displayName = 'PaginationPrevious'
 
 const PaginationNext = ({
@@ -81,14 +89,15 @@ const PaginationNext = ({
 }: React.ComponentProps<typeof PaginationLink>) => (
   <PaginationLink
     aria-label='Go to next page'
-    size='default'
     className={cn('gap-1 pr-2.5', className)}
+    size='default'
     {...props}
   >
     <span>Next</span>
     <ChevronRight className='h-4 w-4' />
   </PaginationLink>
 )
+
 PaginationNext.displayName = 'PaginationNext'
 
 const PaginationEllipsis = ({
@@ -104,6 +113,7 @@ const PaginationEllipsis = ({
     <span className='sr-only'>More pages</span>
   </span>
 )
+
 PaginationEllipsis.displayName = 'PaginationEllipsis'
 
 export {


### PR DESCRIPTION
## Summary
- replace HeroUI button in the file browser's back button
- fix linter error in pagination link by rendering children

## Testing
- `pnpm --dir frontend run format`
- `pnpm --dir frontend run lint`
- `pnpm --dir frontend run build`
- `cargo fmt --manifest-path backend/Cargo.toml`
- `cargo check --manifest-path backend/Cargo.toml`
- `cargo clippy --manifest-path backend/Cargo.toml -- -D warnings`
- `cargo test --manifest-path backend/Cargo.toml` *(fails: failed to load root data)*

------
https://chatgpt.com/codex/tasks/task_e_68568a982ff88320a0f42f42e52542a9