### PR TITLE
Refactor sidebar drawer to shadcn

### DIFF
--- a/frontend/components/blog/Sidebar.tsx
+++ b/frontend/components/blog/Sidebar.tsx
@@ -1,17 +1,12 @@
 'use client'
 
-import {
-  Drawer,
-  DrawerBody,
-  DrawerContent,
-  DrawerHeader,
-  Link,
-  useDisclosure,
-} from '@heroui/react'
 import { ChevronRight } from 'lucide-react'
+import Link from 'next/link'
+import { useState } from 'react'
 
 import { SidebarContent } from './SidebarContent'
 
+import { Drawer, DrawerContent, DrawerHeader } from '@/components/ui/drawer'
 import { t } from '@/i18n'
 import { BlogTreeNode } from '@/lib/mdx/types'
 
@@ -20,13 +15,13 @@ interface Props {
 }
 
 export const BlogSidebar = ({ tree }: Props) => {
-  const { isOpen, onOpen, onOpenChange } = useDisclosure()
+  const [open, setOpen] = useState(false)
 
   return (
     <div className='blog-scroll-nav'>
       <aside className='fixed top-32 hidden h-[calc(100dvh-256px)] w-64 bg-background py-2 md:block'>
         <div className='flex h-full flex-col overflow-scroll border-r border-default-200 bg-background px-4 scrollbar-hide'>
-          <Link className='my-3 text-xl' color='foreground' href='/about'>
+          <Link className='my-3 text-xl' href='/about'>
             {t('navMenuDirectory')}
           </Link>
           <SidebarContent tree={tree} />
@@ -35,24 +30,19 @@ export const BlogSidebar = ({ tree }: Props) => {
 
       <button
         className='fixed left-0 top-0 flex h-full cursor-pointer items-center text-default-500 md:hidden'
-        onClick={() => onOpen()}
+        onClick={() => setOpen(true)}
       >
         <ChevronRight size={24} />
       </button>
 
-      <Drawer
-        isOpen={isOpen}
-        placement='left'
-        size='xs'
-        onOpenChange={onOpenChange}
-      >
+      <Drawer open={open} onOpenChange={setOpen}>
         <DrawerContent>
           <DrawerHeader className='flex flex-col gap-1'>
             {t('navMenuDirectory')}
           </DrawerHeader>
-          <DrawerBody>
+          <div className='px-4'>
             <SidebarContent tree={tree} />
-          </DrawerBody>
+          </div>
         </DrawerContent>
       </Drawer>
     </div>


### PR DESCRIPTION
## Summary
- replace `@heroui/react` drawer in blog sidebar with shadcn drawer

## Testing
- `pnpm run format`
- `pnpm run lint`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_6856933453c88320bba3bc419196c176