### PR TITLE
Implement DI for backend

### DIFF
--- a/backend/src/alg/root.rs
+++ b/backend/src/alg/root.rs
@@ -1,7 +1,7 @@
 use crate::alg::search::{SearchList, aggregate_builder};
 use crate::config::{BucketFiles, NodeValue, TreeNode};
 use anyhow::Result;
-use tokio::{fs, sync::OnceCell};
+use tokio::fs;
 
 /// Generate a hierarchical tree from a flat list of files.
 pub fn generate_tree(file_list: &BucketFiles) -> TreeNode {
@@ -31,32 +31,11 @@ pub fn generate_tree(file_list: &BucketFiles) -> TreeNode {
     root
 }
 
+#[derive(Clone)]
 pub struct Root {
     pub shinnku_tree: TreeNode,
     pub galgame0_tree: TreeNode,
     pub search_index: SearchList,
-}
-
-static ROOT_CELL: OnceCell<Root> = OnceCell::const_new();
-static TREE: OnceCell<TreeNode> = OnceCell::const_new();
-
-async fn init_root() -> Root {
-    load_root().await.expect("failed to load root data")
-}
-
-async fn init_tree() -> TreeNode {
-    let root = get_root().await;
-    build_tree(&root.shinnku_tree, &root.galgame0_tree)
-}
-
-/// Retrieve the global [`Root`] instance, loading it on first access.
-pub async fn get_root() -> &'static Root {
-    ROOT_CELL.get_or_init(init_root).await
-}
-
-/// Retrieve the global combined tree, loading it on first access.
-pub async fn get_tree() -> &'static TreeNode {
-    TREE.get_or_init(init_tree).await
 }
 
 /// Construct the combined tree used by the frontend.

--- a/backend/src/handlers/inode.rs
+++ b/backend/src/handlers/inode.rs
@@ -1,7 +1,8 @@
 use crate::config::{FileInfo, NodeValue, TreeNode};
+use crate::state::AppState;
 use axum::{
     Json,
-    extract::Path,
+    extract::{Path, State},
     http::StatusCode,
     response::{IntoResponse, Response},
 };
@@ -38,16 +39,15 @@ enum Inode {
     File { name: String, info: FileInfo },
 }
 
-pub async fn inode(Path(path): Path<String>) -> impl IntoResponse {
-    inode_impl(path).await
+pub async fn inode(Path(path): Path<String>, State(state): State<AppState>) -> impl IntoResponse {
+    inode_impl(path, &state.tree).await
 }
 
-pub async fn inode_root() -> impl IntoResponse {
-    inode_impl(String::new()).await
+pub async fn inode_root(State(state): State<AppState>) -> impl IntoResponse {
+    inode_impl(String::new(), &state.tree).await
 }
 
-pub async fn inode_impl(path: String) -> Response {
-    let tree = crate::alg::root::get_tree().await;
+pub async fn inode_impl(path: String, tree: &TreeNode) -> Response {
     let mut current = tree;
     let segments: Vec<String> = path
         .split('/')

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -2,17 +2,21 @@ mod alg;
 mod config;
 mod fuse;
 mod handlers;
+mod state;
 
 use anyhow::Result;
 use axum::{Router, routing::get};
 use handlers::*;
+use state::AppState;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    config::get_redis().await;
-    alg::root::get_root().await;
-    alg::root::get_tree().await;
     color_eyre::install().expect("Failed to install error reporting");
+
+    let redis = config::connect_redis().await?;
+    let root = alg::root::load_root().await?;
+    let tree = alg::root::build_tree(&root.shinnku_tree, &root.galgame0_tree);
+    let state = AppState { redis, root, tree };
 
     let app = Router::new()
         .route("/intro", get(intro))
@@ -21,7 +25,8 @@ async fn main() -> Result<()> {
         .route("/conbinesearch", get(combine_search_query))
         .route("/wikisearchpicture", get(wikisearchpicture))
         .route("/files", get(inode_root))
-        .route("/files/{*path}", get(inode));
+        .route("/files/{*path}", get(inode))
+        .with_state(state);
 
     let listener = tokio::net::TcpListener::bind(("127.0.0.1", 2999)).await?;
     let addr = listener.local_addr()?;

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -1,0 +1,9 @@
+use crate::{alg::root::Root, config::TreeNode};
+use redis::aio::ConnectionManager;
+
+#[derive(Clone)]
+pub struct AppState {
+    pub redis: ConnectionManager,
+    pub root: Root,
+    pub tree: TreeNode,
+}


### PR DESCRIPTION
## Summary
- remove OnceCell singletons from the backend
- introduce `AppState` for explicit dependency injection
- wire Redis, Root data and tree through Axum state
- update handlers to use injected state

## Testing
- `cargo fmt`
- `cargo check`
- `cargo clippy`


------
https://chatgpt.com/codex/tasks/task_e_686226c15d088320bf453b6e8d5331cb