### PR TITLE
Improve error handling

### DIFF
--- a/backend/server/src/alg/root.rs
+++ b/backend/server/src/alg/root.rs
@@ -73,8 +73,8 @@ pub fn load_root() -> Result<Root> {
     let shinnku_raw = include_str!("../../../data/shinnku_bucket_files.json");
     let galgame0_raw = include_str!("../../../data/galgame0_bucket_files.json");
 
-    let shinnku_bucket_files: BucketFiles = serde_json::from_str(&shinnku_raw)?;
-    let galgame0_bucket_files: BucketFiles = serde_json::from_str(&galgame0_raw)?;
+    let shinnku_bucket_files: BucketFiles = serde_json::from_str(shinnku_raw)?;
+    let galgame0_bucket_files: BucketFiles = serde_json::from_str(galgame0_raw)?;
 
     let shinnku_tree = generate_tree(&shinnku_bucket_files);
     let galgame0_tree = generate_tree(&galgame0_bucket_files);

--- a/backend/server/src/handlers/intro.rs
+++ b/backend/server/src/handlers/intro.rs
@@ -1,13 +1,19 @@
-use axum::{Json, extract::Query, http::StatusCode, response::IntoResponse};
+use axum::{
+    Json,
+    extract::Query,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
 use reqwest::Client;
 use serde::Deserialize;
+use std::fmt;
 
 #[derive(Deserialize)]
 pub struct NameQuery {
     pub name: Option<String>,
 }
 
-async fn proxy(path: &str, name: Option<String>) -> impl IntoResponse {
+async fn proxy(path: &str, name: Option<String>) -> Result<impl IntoResponse, ProxyError> {
     let client = Client::new();
     let url = format!("http://127.0.0.1:2998{}", path);
     let req = if let Some(ref n) = name {
@@ -15,23 +21,47 @@ async fn proxy(path: &str, name: Option<String>) -> impl IntoResponse {
     } else {
         client.get(&url)
     };
-    match req.send().await {
-        Ok(resp) => {
-            let status = StatusCode::from_u16(resp.status().as_u16())
-                .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
-            match resp.json::<serde_json::Value>().await {
-                Ok(json) => (status, Json(json)).into_response(),
-                Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
-            }
+
+    let resp = req.send().await.map_err(ProxyError::Request)?;
+    let status =
+        StatusCode::from_u16(resp.status().as_u16()).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+    let json = resp
+        .json::<serde_json::Value>()
+        .await
+        .map_err(ProxyError::Json)?;
+    Ok((status, Json(json)))
+}
+
+#[derive(Debug)]
+pub enum ProxyError {
+    Request(reqwest::Error),
+    Json(reqwest::Error),
+}
+
+impl fmt::Display for ProxyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ProxyError::Request(err) => write!(f, "request error: {}", err),
+            ProxyError::Json(err) => write!(f, "json error: {}", err),
         }
-        Err(_) => (StatusCode::BAD_GATEWAY, "Failed to proxy request").into_response(),
     }
 }
 
-pub async fn intro(Query(params): Query<NameQuery>) -> impl IntoResponse {
+impl IntoResponse for ProxyError {
+    fn into_response(self) -> Response {
+        match self {
+            ProxyError::Request(_) => {
+                (StatusCode::BAD_GATEWAY, "Failed to proxy request").into_response()
+            }
+            ProxyError::Json(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+        }
+    }
+}
+
+pub async fn intro(Query(params): Query<NameQuery>) -> Result<impl IntoResponse, ProxyError> {
     proxy("/intro", params.name).await
 }
 
-pub async fn find_name(Query(params): Query<NameQuery>) -> impl IntoResponse {
+pub async fn find_name(Query(params): Query<NameQuery>) -> Result<impl IntoResponse, ProxyError> {
     proxy("/findname", params.name).await
 }


### PR DESCRIPTION
## Summary
- restructure intro request proxy to use `Result` and custom error type
- warn and continue on Redis errors in wiki search
- fix clippy warning in root loader

## Testing
- `cargo fmt --all`
- `cargo check`
- `cargo clippy -- -D warnings`
- `pnpm run format`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686238e4d4d0832093372d8e25b069e4