### PR TITLE
Introduce basic service layer

### DIFF
--- a/backend/server/src/handlers/intro.rs
+++ b/backend/server/src/handlers/intro.rs
@@ -15,7 +15,7 @@ pub struct NameQuery {
 
 async fn proxy(path: &str, name: Option<String>) -> Result<impl IntoResponse, ProxyError> {
     let client = Client::new();
-    let url = format!("http://127.0.0.1:2998{}", path);
+    let url = format!("http://127.0.0.1:2998{path}");
     let req = if let Some(ref n) = name {
         client.get(&url).query(&[("name", n)])
     } else {
@@ -41,8 +41,8 @@ pub enum ProxyError {
 impl fmt::Display for ProxyError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ProxyError::Request(err) => write!(f, "request error: {}", err),
-            ProxyError::Json(err) => write!(f, "json error: {}", err),
+            ProxyError::Request(err) => write!(f, "request error: {err}"),
+            ProxyError::Json(err) => write!(f, "json error: {err}"),
         }
     }
 }

--- a/backend/server/src/main.rs
+++ b/backend/server/src/main.rs
@@ -1,6 +1,7 @@
 mod algorithm;
 mod config;
 mod handlers;
+mod services;
 mod state;
 
 use anyhow::Result;
@@ -29,7 +30,7 @@ async fn main() -> Result<()> {
 
     let listener = tokio::net::TcpListener::bind(("127.0.0.1", 2999)).await?;
     let addr = listener.local_addr()?;
-    println!("Listening on {}", addr);
+    println!("Listening on {addr}");
     axum::serve(listener, app).await?;
     Ok(())
 }

--- a/backend/server/src/services/mod.rs
+++ b/backend/server/src/services/mod.rs
@@ -1,0 +1,1 @@
+pub mod wiki;

--- a/backend/server/src/services/wiki.rs
+++ b/backend/server/src/services/wiki.rs
@@ -1,0 +1,31 @@
+use anyhow::Result;
+use redis::aio::ConnectionManager;
+
+/// Fetch the background image URL for a wiki page by name.
+/// Returns `Ok(None)` if no cached entry is found.
+pub async fn get_wiki_background(
+    con: &mut ConnectionManager,
+    name: &str,
+) -> Result<Option<String>> {
+    let key_search = format!("cache:search:wiki:zh:{name}");
+    let pageid: Option<String> = match redis::cmd("GET").arg(&key_search).query_async(con).await {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("Redis GET {key_search} error: {e}");
+            return Ok(None);
+        }
+    };
+
+    if let Some(pageid) = pageid {
+        let key_img = format!("img:wiki:zh:{pageid}");
+        match redis::cmd("GET").arg(&key_img).query_async(con).await {
+            Ok(bg) => Ok(bg),
+            Err(e) => {
+                eprintln!("Redis GET {key_img} error: {e}");
+                Ok(None)
+            }
+        }
+    } else {
+        Ok(None)
+    }
+}


### PR DESCRIPTION
## Summary
- add `services` module with wiki service
- refactor wiki handler to use the service
- clean up formatting in intro handler and main

## Testing
- `cargo check --manifest-path backend/server/Cargo.toml`
- `cargo clippy --manifest-path backend/server/Cargo.toml -- -D warnings`
- `pnpm run format` *(in frontend)*
- `pnpm build` *(in frontend, build output truncated)*


------
https://chatgpt.com/codex/tasks/task_e_6862411750348320b3de88b0b050def9