### PR TITLE
Remove async wrappers for inode

### DIFF
--- a/backend/server/src/handlers/inode.rs
+++ b/backend/server/src/handlers/inode.rs
@@ -39,18 +39,16 @@ enum Inode {
     File { name: String, info: FileInfo },
 }
 
-pub async fn get_node(
-    Path(path): Path<String>,
-    State(state): State<AppState>,
-) -> impl IntoResponse {
-    get_node_impl(path, &state.tree).await
+// Synchronous helpers used by the router closures
+pub fn get_node(Path(path): Path<String>, State(state): State<AppState>) -> Response {
+    get_node_impl(&path, &state.tree)
 }
 
-pub async fn get_node_root(State(state): State<AppState>) -> impl IntoResponse {
-    get_node_impl(String::new(), &state.tree).await
+pub fn get_node_root(State(state): State<AppState>) -> Response {
+    get_node_impl("", &state.tree)
 }
 
-pub async fn get_node_impl(path: String, tree: &TreeNode) -> Response {
+pub fn get_node_impl(path: &str, tree: &TreeNode) -> Response {
     let mut current = tree;
     let segments: Vec<String> = path
         .split('/')

--- a/backend/server/src/main.rs
+++ b/backend/server/src/main.rs
@@ -5,8 +5,14 @@ mod services;
 mod state;
 
 use anyhow::Result;
-use axum::{Router, routing::get};
-use handlers::*;
+use axum::{
+    Router,
+    extract::{Path, State},
+    routing::get,
+};
+use handlers::{
+    find_name, get_node, get_node_root, intro, search, search_combined, wiki_search_picture,
+};
 use state::AppState;
 
 #[tokio::main]
@@ -24,8 +30,14 @@ async fn main() -> Result<()> {
         .route("/search", get(search))
         .route("/combinesearch", get(search_combined))
         .route("/wikisearchpicture", get(wiki_search_picture))
-        .route("/files", get(get_node_root))
-        .route("/files/{*path}", get(get_node))
+        .route(
+            "/files",
+            get(|state: State<AppState>| async move { get_node_root(state) }),
+        )
+        .route(
+            "/files/{*path}",
+            get(|path: Path<String>, state: State<AppState>| async move { get_node(path, state) }),
+        )
         .with_state(state);
 
     let listener = tokio::net::TcpListener::bind(("127.0.0.1", 2999)).await?;


### PR DESCRIPTION
## Summary
- use sync helpers for inode routes instead of async wrappers

## Testing
- `cargo fmt`
- `cargo check`
- `cargo clippy -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_68624f08988c83209810152e27697f5d