### PR TITLE
Unify backend error handling and logging

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -778,6 +778,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -863,6 +873,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owo-colors"
@@ -1273,8 +1289,11 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio",
  "toml",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1389,6 +1408,26 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1567,7 +1606,19 @@ checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1591,14 +1642,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
+ "nu-ansi-term",
  "sharded-slab",
+ "smallvec",
  "thread_local",
  "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1752,6 +1817,28 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/backend/server/Cargo.toml
+++ b/backend/server/Cargo.toml
@@ -11,6 +11,9 @@ tokio = { version = "1.45.0", features = ["full"] }
 reqwest = { version = "0.12.19", features = ["json"] }
 anyhow = "1"
 color-eyre = "0.6"
+thiserror = "1"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["fmt"] }
 percent-encoding = "2"
 redis = { version = "0.32", features = ["tokio-comp", "cluster-async", "connection-manager"] }
 toml = "0.8.23"

--- a/backend/server/src/algorithm/root.rs
+++ b/backend/server/src/algorithm/root.rs
@@ -101,8 +101,8 @@ mod tests {
     #[test]
     fn test_load_root() -> Result<()> {
         let root = load_root()?;
-        println!("Shinnku tree: {:?}", root.shinnku_tree);
-        println!("Galgame0 tree: {:?}", root.galgame0_tree);
+        tracing::info!("Shinnku tree: {:?}", root.shinnku_tree);
+        tracing::info!("Galgame0 tree: {:?}", root.galgame0_tree);
         Ok(())
     }
 }

--- a/backend/server/src/config.rs
+++ b/backend/server/src/config.rs
@@ -62,7 +62,7 @@ mod tests {
     async fn test_redis_get_set() {
         // Skip if no config.toml is present
         if !std::path::Path::new("config.toml").exists() {
-            eprintln!("Skipping redis test: config.toml not found");
+            tracing::warn!("Skipping redis test: config.toml not found");
             return;
         }
         let mut con = connect_redis().await.unwrap();
@@ -72,6 +72,6 @@ mod tests {
             .query_async(&mut con)
             .await
             .unwrap();
-        println!("Value for {}: {}", key, res);
+        tracing::info!("Value for {}: {}", key, res);
     }
 }

--- a/backend/server/src/error.rs
+++ b/backend/server/src/error.rs
@@ -1,0 +1,38 @@
+use axum::{
+    Json,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+use serde::Serialize;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum AppError {
+    #[error("configuration error: {0}")]
+    Config(#[from] anyhow::Error),
+    #[error("database error: {0}")]
+    Database(#[from] redis::RedisError),
+    #[error("network error: {0}")]
+    Network(#[from] reqwest::Error),
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("serialization error: {0}")]
+    Serde(#[from] serde_json::Error),
+}
+
+#[derive(Serialize)]
+struct ErrorResponse<'a> {
+    message: &'a str,
+}
+
+impl IntoResponse for AppError {
+    fn into_response(self) -> Response {
+        let status = match self {
+            AppError::Network(_) => StatusCode::BAD_GATEWAY,
+            _ => StatusCode::INTERNAL_SERVER_ERROR,
+        };
+        let msg = self.to_string();
+        let body = Json(ErrorResponse { message: &msg });
+        (status, body).into_response()
+    }
+}

--- a/backend/server/src/handlers/inode.rs
+++ b/backend/server/src/handlers/inode.rs
@@ -1,4 +1,5 @@
 use crate::config::{FileInfo, NodeType, TreeNode};
+use crate::error::AppError;
 use crate::state::AppState;
 use axum::{
     Json,
@@ -40,12 +41,15 @@ enum Inode {
 }
 
 // Synchronous helpers used by the router closures
-pub async fn get_node(Path(path): Path<String>, State(state): State<AppState>) -> Response {
-    get_node_impl(&path, &state.tree)
+pub async fn get_node(
+    Path(path): Path<String>,
+    State(state): State<AppState>,
+) -> Result<impl IntoResponse, AppError> {
+    Ok(get_node_impl(&path, &state.tree))
 }
 
-pub async fn get_node_root(State(state): State<AppState>) -> Response {
-    get_node_impl("", &state.tree)
+pub async fn get_node_root(State(state): State<AppState>) -> Result<impl IntoResponse, AppError> {
+    Ok(get_node_impl("", &state.tree))
 }
 
 pub fn get_node_impl(path: &str, tree: &TreeNode) -> Response {

--- a/backend/server/src/handlers/intro.rs
+++ b/backend/server/src/handlers/intro.rs
@@ -1,19 +1,14 @@
-use axum::{
-    Json,
-    extract::Query,
-    http::StatusCode,
-    response::{IntoResponse, Response},
-};
+use crate::error::AppError;
+use axum::{Json, extract::Query, http::StatusCode, response::IntoResponse};
 use reqwest::Client;
 use serde::Deserialize;
-use std::fmt;
 
 #[derive(Deserialize)]
 pub struct NameQuery {
     pub name: Option<String>,
 }
 
-async fn proxy(path: &str, name: Option<String>) -> Result<impl IntoResponse, ProxyError> {
+async fn proxy(path: &str, name: Option<String>) -> Result<impl IntoResponse, AppError> {
     let client = Client::new();
     let url = format!("http://127.0.0.1:2998{path}");
     let req = if let Some(ref n) = name {
@@ -22,46 +17,17 @@ async fn proxy(path: &str, name: Option<String>) -> Result<impl IntoResponse, Pr
         client.get(&url)
     };
 
-    let resp = req.send().await.map_err(ProxyError::Request)?;
+    let resp = req.send().await?;
     let status =
         StatusCode::from_u16(resp.status().as_u16()).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
-    let json = resp
-        .json::<serde_json::Value>()
-        .await
-        .map_err(ProxyError::Json)?;
+    let json = resp.json::<serde_json::Value>().await?;
     Ok((status, Json(json)))
 }
 
-#[derive(Debug)]
-pub enum ProxyError {
-    Request(reqwest::Error),
-    Json(reqwest::Error),
-}
-
-impl fmt::Display for ProxyError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            ProxyError::Request(err) => write!(f, "request error: {err}"),
-            ProxyError::Json(err) => write!(f, "json error: {err}"),
-        }
-    }
-}
-
-impl IntoResponse for ProxyError {
-    fn into_response(self) -> Response {
-        match self {
-            ProxyError::Request(_) => {
-                (StatusCode::BAD_GATEWAY, "Failed to proxy request").into_response()
-            }
-            ProxyError::Json(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
-        }
-    }
-}
-
-pub async fn intro(Query(params): Query<NameQuery>) -> Result<impl IntoResponse, ProxyError> {
+pub async fn intro(Query(params): Query<NameQuery>) -> Result<impl IntoResponse, AppError> {
     proxy("/intro", params.name).await
 }
 
-pub async fn find_name(Query(params): Query<NameQuery>) -> Result<impl IntoResponse, ProxyError> {
+pub async fn find_name(Query(params): Query<NameQuery>) -> Result<impl IntoResponse, AppError> {
     proxy("/findname", params.name).await
 }

--- a/backend/server/src/handlers/wiki.rs
+++ b/backend/server/src/handlers/wiki.rs
@@ -1,3 +1,4 @@
+use crate::error::AppError;
 use crate::services::wiki::get_wiki_background;
 use crate::state::AppState;
 use axum::{
@@ -22,10 +23,10 @@ pub struct WikiPictureResponse {
 pub async fn wiki_search_picture(
     State(state): State<AppState>,
     Query(params): Query<WikiPictureQuery>,
-) -> impl IntoResponse {
+) -> Result<impl IntoResponse, AppError> {
     let name = match params.name {
         Some(n) => n,
-        None => return StatusCode::BAD_REQUEST.into_response(),
+        None => return Ok(StatusCode::BAD_REQUEST.into_response()),
     };
 
     let mut con: ConnectionManager = state.redis.clone();
@@ -34,5 +35,5 @@ pub async fn wiki_search_picture(
         .await
         .unwrap_or_default();
 
-    (StatusCode::OK, Json(WikiPictureResponse { bg })).into_response()
+    Ok((StatusCode::OK, Json(WikiPictureResponse { bg })).into_response())
 }

--- a/backend/server/src/main.rs
+++ b/backend/server/src/main.rs
@@ -4,14 +4,18 @@ mod handlers;
 mod services;
 mod state;
 
-use anyhow::Result;
 use axum::{Router, routing::get};
 use handlers::*;
 use state::AppState;
+use tracing::info;
+use tracing_subscriber::fmt;
+mod error;
+use error::AppError;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), AppError> {
     color_eyre::install().expect("Failed to install error reporting");
+    fmt::init();
 
     let redis = config::connect_redis().await?;
     let root = algorithm::root::load_root()?;
@@ -30,7 +34,7 @@ async fn main() -> Result<()> {
 
     let listener = tokio::net::TcpListener::bind(("127.0.0.1", 2999)).await?;
     let addr = listener.local_addr()?;
-    println!("Listening on {addr}");
+    info!("Listening on {addr}");
     axum::serve(listener, app).await?;
     Ok(())
 }

--- a/backend/server/src/services/wiki.rs
+++ b/backend/server/src/services/wiki.rs
@@ -11,7 +11,7 @@ pub async fn get_wiki_background(
     let pageid: Option<String> = match redis::cmd("GET").arg(&key_search).query_async(con).await {
         Ok(v) => v,
         Err(e) => {
-            eprintln!("Redis GET {key_search} error: {e}");
+            tracing::error!("Redis GET {key_search} error: {e}");
             return Ok(None);
         }
     };
@@ -21,7 +21,7 @@ pub async fn get_wiki_background(
         match redis::cmd("GET").arg(&key_img).query_async(con).await {
             Ok(bg) => Ok(bg),
             Err(e) => {
-                eprintln!("Redis GET {key_img} error: {e}");
+                tracing::error!("Redis GET {key_img} error: {e}");
                 Ok(None)
             }
         }


### PR DESCRIPTION
## Summary
- add tracing and thiserror dependencies
- implement global `AppError` with `IntoResponse`
- update handlers and main to return `Result<_, AppError>`
- log via `tracing` instead of `println!`

## Testing
- `cargo fmt`
- `cargo check`
- `cargo clippy -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_6862526f5f3c8320a34b50a0772c45f0