### PR TITLE
Refactor backend file tree models

### DIFF
--- a/backend/server/src/algorithm/root.rs
+++ b/backend/server/src/algorithm/root.rs
@@ -1,5 +1,5 @@
 use crate::algorithm::search::{SearchList, aggregate_builder};
-use crate::config::{BucketFiles, NodeType, TreeNode};
+use crate::models::{BucketFiles, NodeType, TreeNode};
 use anyhow::Result;
 
 /// Generate a hierarchical tree from a flat list of files.

--- a/backend/server/src/algorithm/search.rs
+++ b/backend/server/src/algorithm/search.rs
@@ -1,4 +1,4 @@
-use crate::config::{BucketFiles, FileInfo};
+use crate::models::{BucketFiles, FileInfo};
 use fuse_lib::lib::{Fuse, FuseProperty, Fuseable};
 use serde::{Deserialize, Serialize};
 

--- a/backend/server/src/config.rs
+++ b/backend/server/src/config.rs
@@ -1,25 +1,7 @@
 use anyhow::Result;
 use redis::{Client, aio::ConnectionManager};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use tokio::fs;
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct FileInfo {
-    pub file_path: String,
-    pub upload_timestamp: u64,
-    pub file_size: u64,
-}
-
-pub type BucketFiles = Vec<FileInfo>;
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum NodeType {
-    File(FileInfo),
-    Node(TreeNode),
-}
-
-pub type TreeNode = HashMap<String, NodeType>;
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct Settings {

--- a/backend/server/src/handlers/inode.rs
+++ b/backend/server/src/handlers/inode.rs
@@ -1,5 +1,5 @@
-use crate::config::{FileInfo, NodeType, TreeNode};
 use crate::error::AppError;
+use crate::models::{FileInfo, NodeType, TreeNode};
 use crate::state::AppState;
 use axum::{
     Json,

--- a/backend/server/src/main.rs
+++ b/backend/server/src/main.rs
@@ -1,6 +1,7 @@
 mod algorithm;
 mod config;
 mod handlers;
+mod models;
 mod services;
 mod state;
 

--- a/backend/server/src/models.rs
+++ b/backend/server/src/models.rs
@@ -1,0 +1,20 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FileInfo {
+    pub file_path: String,
+    pub upload_timestamp: u64,
+    pub file_size: u64,
+}
+
+pub type BucketFiles = Vec<FileInfo>;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum NodeType {
+    File(FileInfo),
+    Node(TreeNode),
+}
+
+pub type TreeNode = HashMap<String, NodeType>;

--- a/backend/server/src/state.rs
+++ b/backend/server/src/state.rs
@@ -1,4 +1,4 @@
-use crate::{algorithm::root::Root, config::TreeNode};
+use crate::{algorithm::root::Root, models::TreeNode};
 use redis::aio::ConnectionManager;
 
 #[derive(Clone)]


### PR DESCRIPTION
## Summary
- move FileInfo, BucketFiles, NodeType and TreeNode into new `models` module
- import the new module across backend files
- cleanup `config.rs`

## Testing
- `cargo fmt --all`
- `cargo check`
- `cargo clippy -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_686254e053e883209e6824740f61f27b