### PR TITLE
Move inode types to models and rename handler file

### DIFF
--- a/backend/server/src/handlers/files.rs
+++ b/backend/server/src/handlers/files.rs
@@ -1,5 +1,8 @@
 use crate::error::AppError;
-use crate::models::{FileInfo, NodeType, TreeNode};
+use crate::models::{
+    NodeType, TreeNode,
+    inode::{Inode, node2list},
+};
 use crate::state::AppState;
 use axum::{
     Json,
@@ -8,37 +11,6 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use percent_encoding::percent_decode_str;
-use serde::Serialize;
-
-#[derive(Serialize, Clone)]
-#[serde(tag = "type")]
-pub enum Node {
-    #[serde(rename = "file")]
-    File { name: String, info: FileInfo },
-    #[serde(rename = "folder")]
-    Folder { name: String },
-}
-
-fn node2list(node: &TreeNode) -> Vec<Node> {
-    node.iter()
-        .map(|(name, value)| match value {
-            NodeType::File(info) => Node::File {
-                name: name.clone(),
-                info: info.clone(),
-            },
-            NodeType::Node(_) => Node::Folder { name: name.clone() },
-        })
-        .collect()
-}
-
-#[derive(Serialize)]
-#[serde(tag = "type")]
-enum Inode {
-    #[serde(rename = "folder")]
-    Folder { data: Vec<Node> },
-    #[serde(rename = "file")]
-    File { name: String, info: FileInfo },
-}
 
 // Synchronous helpers used by the router closures
 pub async fn get_node(

--- a/backend/server/src/handlers/mod.rs
+++ b/backend/server/src/handlers/mod.rs
@@ -1,9 +1,9 @@
-pub mod inode;
+pub mod files;
 pub mod intro;
 pub mod search;
 pub mod wiki;
 
-pub use inode::{get_node, get_node_root};
+pub use files::{get_node, get_node_root};
 pub use intro::{find_name, intro};
 pub use search::{search, search_combined};
 pub use wiki::wiki_search_picture;

--- a/backend/server/src/models.rs
+++ b/backend/server/src/models.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+pub mod inode;
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct FileInfo {
     pub file_path: String,

--- a/backend/server/src/models/inode.rs
+++ b/backend/server/src/models/inode.rs
@@ -1,0 +1,32 @@
+use super::{FileInfo, NodeType, TreeNode};
+use serde::Serialize;
+
+#[derive(Serialize, Clone)]
+#[serde(tag = "type")]
+pub enum Node {
+    #[serde(rename = "file")]
+    File { name: String, info: FileInfo },
+    #[serde(rename = "folder")]
+    Folder { name: String },
+}
+
+pub fn node2list(node: &TreeNode) -> Vec<Node> {
+    node.iter()
+        .map(|(name, value)| match value {
+            NodeType::File(info) => Node::File {
+                name: name.clone(),
+                info: info.clone(),
+            },
+            NodeType::Node(_) => Node::Folder { name: name.clone() },
+        })
+        .collect()
+}
+
+#[derive(Serialize)]
+#[serde(tag = "type")]
+pub enum Inode {
+    #[serde(rename = "folder")]
+    Folder { data: Vec<Node> },
+    #[serde(rename = "file")]
+    File { name: String, info: FileInfo },
+}


### PR DESCRIPTION
## Summary
- move filesystem types from handlers to new `models/inode.rs`
- rename `handlers/inode.rs` to `handlers/files.rs`
- update module exports

## Testing
- `cargo fmt`
- `cargo check`
- `cargo clippy -- -D warnings`
- `pnpm run format`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6862569daa2c83208980e0598b08e6c1