### PR TITLE
Refactor backend router using Axum submodules

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1074,7 +1074,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tower",
- "tower-http",
+ "tower-http 0.6.6",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -1293,6 +1293,7 @@ dependencies = [
  "tokio",
  "toml",
  "tower",
+ "tower-http 0.5.2",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1564,6 +1565,23 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/backend/server/Cargo.toml
+++ b/backend/server/Cargo.toml
@@ -19,6 +19,7 @@ redis = { version = "0.32", features = ["tokio-comp", "cluster-async", "connecti
 toml = "0.8.23"
 fuse-lib = { path = "../fuse" }
 tower = "0.5.2"
+tower-http = { version = "0.5", features = ["trace"] }
 
 [[bin]]
 name = "shinnku-com-backend"

--- a/backend/server/src/handlers/mod.rs
+++ b/backend/server/src/handlers/mod.rs
@@ -2,8 +2,3 @@ pub mod files;
 pub mod intro;
 pub mod search;
 pub mod wiki;
-
-pub use files::{get_node, get_node_root};
-pub use intro::{find_name, intro};
-pub use search::{search, search_combined};
-pub use wiki::wiki_search_picture;

--- a/backend/server/src/routes/files.rs
+++ b/backend/server/src/routes/files.rs
@@ -1,0 +1,9 @@
+use crate::handlers::files::{get_node, get_node_root};
+use crate::state::AppState;
+use axum::{Router, routing::get};
+
+pub fn router() -> Router<AppState> {
+    Router::new()
+        .route("/", get(get_node_root))
+        .route("/*path", get(get_node))
+}

--- a/backend/server/src/routes/mod.rs
+++ b/backend/server/src/routes/mod.rs
@@ -1,0 +1,19 @@
+pub mod files;
+
+use crate::handlers::{
+    intro::{find_name, intro},
+    search::{search, search_combined},
+    wiki::wiki_search_picture,
+};
+use crate::state::AppState;
+use axum::{Router, routing::get};
+
+pub fn app_router() -> Router<AppState> {
+    Router::new()
+        .route("/intro", get(intro))
+        .route("/findname", get(find_name))
+        .route("/search", get(search))
+        .route("/combinesearch", get(search_combined))
+        .route("/wikisearchpicture", get(wiki_search_picture))
+        .nest("/files", files::router())
+}


### PR DESCRIPTION
## Summary
- split main Axum routes into a new `routes` module
- add dedicated router for `/files`
- apply `TraceLayer` middleware for request logging
- update dependencies for `tower-http`

## Testing
- `cargo fmt`
- `cargo check`
- `cargo clippy -- -D warnings`

------
https://chatgpt.com/codex/tasks/task_e_6865dfeb6ff88320a9e303492c4698b5