### PR TITLE
Improve backend error handling

### DIFF
--- a/backend/server/src/error.rs
+++ b/backend/server/src/error.rs
@@ -8,6 +8,12 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum AppError {
+    #[error("Bad request: {0}")]
+    BadRequest(String),
+    #[error("Not found: {0}")]
+    NotFound(String),
+    #[error("Internal error: {0}")]
+    Internal(String),
     #[error("configuration error: {0}")]
     Config(#[from] anyhow::Error),
     #[error("database error: {0}")]
@@ -27,11 +33,13 @@ struct ErrorResponse<'a> {
 
 impl IntoResponse for AppError {
     fn into_response(self) -> Response {
-        let status = match self {
-            AppError::Network(_) => StatusCode::BAD_GATEWAY,
-            _ => StatusCode::INTERNAL_SERVER_ERROR,
+        let (status, msg) = match &self {
+            AppError::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg.clone()),
+            AppError::NotFound(msg) => (StatusCode::NOT_FOUND, msg.clone()),
+            AppError::Internal(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg.clone()),
+            AppError::Network(e) => (StatusCode::BAD_GATEWAY, e.to_string()),
+            _ => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
         };
-        let msg = self.to_string();
         let body = Json(ErrorResponse { message: &msg });
         (status, body).into_response()
     }

--- a/backend/server/src/handlers/search.rs
+++ b/backend/server/src/handlers/search.rs
@@ -26,10 +26,9 @@ pub async fn search(
     State(state): State<AppState>,
     Query(params): Query<SearchQuery>,
 ) -> Result<impl IntoResponse, AppError> {
-    let q = match params.q {
-        Some(q) => q,
-        None => return Ok(StatusCode::BAD_REQUEST.into_response()),
-    };
+    let q = params
+        .q
+        .ok_or_else(|| AppError::BadRequest("missing `q` query param".into()))?;
 
     let search_index = &state.root.search_index;
     let n = params.n.unwrap_or(100);
@@ -44,7 +43,11 @@ pub async fn search_combined(
 ) -> Result<impl IntoResponse, AppError> {
     let (q1, q2) = match (params.q1, params.q2) {
         (Some(q1), Some(q2)) => (q1, q2),
-        _ => return Ok(StatusCode::BAD_REQUEST.into_response()),
+        _ => {
+            return Err(AppError::BadRequest(
+                "missing `q1` and/or `q2` query param".into(),
+            ));
+        }
     };
 
     let search_index = &state.root.search_index;

--- a/backend/server/src/handlers/wiki.rs
+++ b/backend/server/src/handlers/wiki.rs
@@ -24,10 +24,9 @@ pub async fn wiki_search_picture(
     State(state): State<AppState>,
     Query(params): Query<WikiPictureQuery>,
 ) -> Result<impl IntoResponse, AppError> {
-    let name = match params.name {
-        Some(n) => n,
-        None => return Ok(StatusCode::BAD_REQUEST.into_response()),
-    };
+    let name = params
+        .name
+        .ok_or_else(|| AppError::BadRequest("missing `name` query param".into()))?;
 
     let mut con: ConnectionManager = state.redis.clone();
 


### PR DESCRIPTION
## Summary
- expand `AppError` with `BadRequest`, `NotFound`, and `Internal` variants
- implement HTTP status matching for new variants
- use typed errors in search and wiki handlers
- propagate `NotFound` from file node helper

## Testing
- `cargo fmt --all`
- `cargo check`
- `cargo clippy`

------
https://chatgpt.com/codex/tasks/task_e_6865eafda0d88320bc404746c2e81352