### PR TITLE
Add zod validation for search and blog posts

### DIFF
--- a/frontend/lib/search.ts
+++ b/frontend/lib/search.ts
@@ -1,4 +1,4 @@
-import { SearchItem } from '@/types'
+import { SearchItem, SearchItemSchema } from './validation'
 
 export async function ai_search(q: string, n: number): Promise<SearchItem[]> {
   const serviceUrl = process.env.BACKEND_URL || 'http://localhost:2999'
@@ -11,11 +11,15 @@ export async function ai_search(q: string, n: number): Promise<SearchItem[]> {
 
   let url = `${serviceUrl}/combinesearch?q1=${encodeURIComponent(queryai)}&q2=${encodeURIComponent(q)}&n=${n}`
 
-  const results: SearchItem[] = await fetch(url)
+  const raw = await fetch(url)
     .then((res) => res.json())
     .catch(() => [])
 
-  return results
+  try {
+    return SearchItemSchema.array().parse(raw)
+  } catch {
+    return []
+  }
 }
 
 export async function default_search(
@@ -24,11 +28,15 @@ export async function default_search(
 ): Promise<SearchItem[]> {
   const serviceUrl = process.env.BACKEND_URL || 'http://localhost:2999'
 
-  const results: SearchItem[] = await fetch(
+  const raw = await fetch(
     `${serviceUrl}/search?q=${encodeURIComponent(q)}&n=${n}`,
   )
     .then((res) => res.json())
     .catch(() => [])
 
-  return results
+  try {
+    return SearchItemSchema.array().parse(raw)
+  } catch {
+    return []
+  }
 }

--- a/frontend/lib/validation.ts
+++ b/frontend/lib/validation.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod'
+
+export const FileInfoSchema = z.object({
+  file_path: z.string(),
+  upload_timestamp: z.number(),
+  file_size: z.number(),
+})
+export type FileInfo = z.infer<typeof FileInfoSchema>
+
+export const SearchItemSchema = z.object({
+  id: z.string(),
+  info: FileInfoSchema,
+})
+export type SearchItem = z.infer<typeof SearchItemSchema>
+export const SearchListSchema = z.array(SearchItemSchema)
+export type SearchList = z.infer<typeof SearchListSchema>
+
+export const BlogFrontmatterSchema = z.object({
+  title: z.string(),
+  banner: z.string(),
+  description: z.string(),
+  date: z
+    .union([z.string(), z.date()])
+    .transform((v) => (v instanceof Date ? v.toISOString() : v)),
+  authorUid: z.number(),
+  authorName: z.string(),
+  authorAvatar: z.string(),
+  authorHomepage: z.string(),
+})
+export type BlogFrontmatter = z.infer<typeof BlogFrontmatterSchema>


### PR DESCRIPTION
## Summary
- add `validation.ts` with zod schemas
- validate search API responses
- validate MDX frontmatter when loading posts

## Testing
- `pnpm run format`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68662bc9d55c83209b9bff995ee3feef